### PR TITLE
fix: styled-components prop leaking warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-codecopy",
   "description": "\"Copy to clipboard button\" for your code snippets",
-  "homepage": "https://github.com/Kikobeats/react-codecopy",
+  "homepage": "https://react-codecopy.vercel.app",
   "version": "5.0.4",
   "main": "dist/codecopy.js",
   "module": "dist/codecopy.mjs",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "peerDependencies": {
     "react": ">= 16 < 19",
-    "styled-components": ">=5"
+    "styled-components": ">=5.1"
   },
   "simple-git-hooks": {
     "commit-msg": "npx commitlint --edit",

--- a/src/button.js
+++ b/src/button.js
@@ -38,7 +38,7 @@ export default styled.button`
     box-shadow: ${button.boxShadow};
     min-height: initial;
     transition: opacity 0.3s ease-in-out;
-    opacity: ${props => (props.isHover ? '1' : '0')};
+    opacity: ${props => (props.$isHover ? '1' : '0')};
     z-index: 1;
 
     &:focus {
@@ -83,9 +83,8 @@ export default styled.button`
       z-index: 1000000;
       display: none;
       padding: 0.5em 0.75em;
-      font: normal normal 11px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-        'Segoe UI Symbol';
+      font: normal normal 11px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+        sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
       -webkit-font-smoothing: subpixel-antialiased;
       color: ${tooltip.color};
       text-align: center;

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const CodeCopy = ({ iconComponent: IconComponent, copy = native, onCopy, ...prop
       >
         <ClipboardButton
           className={`codecopy__button codecopy__button__${theme}`}
-          isHover={isHover || props.interactive}
+          $isHover={isHover || props.interactive}
           aria-label={label}
           onMouseLeave={() => setLabel(labels.copy)}
           onClick={() => copy(text).then(() => setLabel(labels.copied))}


### PR DESCRIPTION
This fixes the React warning about the `isHover` prop leaking through to the DOM, by using a transient prop

<img width="780" alt="image" src="https://github.com/Kikobeats/react-codecopy/assets/5795227/d86522c0-8a4f-4a17-a53a-9ff5b50ffab3">




